### PR TITLE
changes due min ios 13.0 for cornerCurve

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .library(name: "PrettyCards", targets: ["PrettyCards"])
     ],
     targets: [
-        .target(name: "PrettyCards", path: "Source")
+        .target(name: "PrettyCards", path: "Sources")
     ],
     swiftLanguageVersions: [
         .v5

--- a/Sources/Card.swift
+++ b/Sources/Card.swift
@@ -96,8 +96,10 @@ open class Card: UIView, UIGestureRecognizerDelegate {
 
     private func configure() {
         self.layer.masksToBounds = false
-        self.layer.cornerCurve = .continuous
-        self.containerView.layer.cornerCurve = .continuous
+        if #available(iOS 13.0, *) {
+            self.layer.cornerCurve = .continuous
+            self.containerView.layer.cornerCurve = .continuous
+        }
         self.clipsToBounds = false
         self.isExclusiveTouch = true
         self.isUserInteractionEnabled = true


### PR DESCRIPTION
cornerCure is available since iOS 13.0. There are only two ways to fix this error, up the min version to iOS 13 or mark as available. I decided to mark lines of code as available. Also, package manifest has been fixed due incorrect path name.